### PR TITLE
performance improvement on TF2

### DIFF
--- a/utils_tf2.py
+++ b/utils_tf2.py
@@ -56,7 +56,7 @@ class ModelAdapter():
         return xent
 
     @tf.function
-    def _get_grad_xent(self, x_input, y_input):
+    def __get_grad_xent(self, x_input, y_input):
         with tf.GradientTape(watch_accessed_variables=False) as g:
             g.watch(x_input)
             logits = self.__get_logits(x_input)
@@ -146,7 +146,7 @@ class ModelAdapter():
         if self.data_format == 'channels_last':
             x2 = tf.transpose(x2, perm=[0,2,3,1])
 
-        logits_val, loss_indiv_val, grad_val = self._get_grad_xent(x2, y2)
+        logits_val, loss_indiv_val, grad_val = self.__get_grad_xent(x2, y2)
 
         if self.data_format == 'channels_last':
             grad_val = tf.transpose(grad_val, perm=[0,3,1,2])

--- a/utils_tf2.py
+++ b/utils_tf2.py
@@ -38,6 +38,7 @@ class ModelAdapter():
         logits = self.tf_model(x_input, training=False)
         return logits
 
+    @tf.function
     def __get_jacobian(self, x_input):
         with tf.GradientTape(watch_accessed_variables=False) as g:
             g.watch(x_input)
@@ -54,6 +55,7 @@ class ModelAdapter():
         xent   = tf.nn.sparse_softmax_cross_entropy_with_logits(logits=logits, labels=y_input)
         return xent
 
+    @tf.function
     def _get_grad_xent(self, x_input, y_input):
         with tf.GradientTape(watch_accessed_variables=False) as g:
             g.watch(x_input)
@@ -64,10 +66,12 @@ class ModelAdapter():
 
         return logits, xent, grad_xent
 
+    @tf.function
     def __get_dlr(self, logits, y_input):
         val_dlr = dlr_loss(logits, y_input, num_classes=self.num_classes)
         return val_dlr
 
+    @tf.function
     def __get_grad_dlr(self, x_input, y_input):
         with tf.GradientTape(watch_accessed_variables=False) as g:
             g.watch(x_input)
@@ -82,6 +86,7 @@ class ModelAdapter():
         dlr_target = dlr_loss_targeted(logits, y_input, y_target, num_classes=self.num_classes)
         return dlr_target
 
+    @tf.function
     def __get_grad_dlr_target(self, x_input, y_input, y_target):
         with tf.GradientTape(watch_accessed_variables=False) as g:
             g.watch(x_input)

--- a/utils_tf2.py
+++ b/utils_tf2.py
@@ -66,7 +66,6 @@ class ModelAdapter():
 
         return logits, xent, grad_xent
 
-    @tf.function
     def __get_dlr(self, logits, y_input):
         val_dlr = dlr_loss(logits, y_input, num_classes=self.num_classes)
         return val_dlr


### PR DESCRIPTION
After deep investigation, the poor performance on TF2 is caused by some implementation details.

This PR has fixed this issue.

There is the output:

```
[INFO] set data_format = 'channels_last'
initial accuracy: 97.74%
WARNING:tensorflow:AutoGraph could not transform <bound method ModelAdapter._get_grad_xent of <tensorflow.python.eager.function.TfMethodTarget object at 0x7f4c5809fdd8>> and will run it as-is.
Cause: mangled names are not yet supported
To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert
apgd-ce - 1/10 - 96 out of 1000 successfully perturbed
apgd-ce - 2/10 - 130 out of 1000 successfully perturbed
apgd-ce - 3/10 - 106 out of 1000 successfully perturbed
apgd-ce - 4/10 - 104 out of 1000 successfully perturbed
apgd-ce - 5/10 - 95 out of 1000 successfully perturbed
apgd-ce - 6/10 - 73 out of 1000 successfully perturbed
apgd-ce - 7/10 - 51 out of 1000 successfully perturbed
apgd-ce - 8/10 - 57 out of 1000 successfully perturbed
apgd-ce - 9/10 - 29 out of 1000 successfully perturbed
apgd-ce - 10/10 - 73 out of 774 successfully perturbed
robust accuracy after APGD-CE: 89.60% (total time 55.6 s)
WARNING:tensorflow:AutoGraph could not transform <bound method ModelAdapter.__get_grad_dlr of <tensorflow.python.eager.function.TfMethodTarget object at 0x7f4c58067a90>> and will run it as-is.
Cause: mangled names are not yet supported
To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert
apgd-dlr - 1/9 - 8 out of 1000 successfully perturbed
apgd-dlr - 2/9 - 20 out of 1000 successfully perturbed
apgd-dlr - 3/9 - 7 out of 1000 successfully perturbed
apgd-dlr - 4/9 - 15 out of 1000 successfully perturbed
apgd-dlr - 5/9 - 4 out of 1000 successfully perturbed
apgd-dlr - 6/9 - 6 out of 1000 successfully perturbed
apgd-dlr - 7/9 - 5 out of 1000 successfully perturbed
apgd-dlr - 8/9 - 7 out of 1000 successfully perturbed
apgd-dlr - 9/9 - 7 out of 960 successfully perturbed
robust accuracy after APGD-DLR: 88.81% (total time 123.2 s)
WARNING:tensorflow:AutoGraph could not transform <bound method ModelAdapter.__get_jacobian of <tensorflow.python.eager.function.TfMethodTarget object at 0x7f4c001f1cf8>> and will run it as-is.
Cause: mangled names are not yet supported
To silence this warning, decorate the function with @tf.autograph.experimental.do_not_convert
fab - 1/9 - 1 out of 1000 successfully perturbed
fab - 2/9 - 4 out of 1000 successfully perturbed
fab - 3/9 - 1 out of 1000 successfully perturbed
fab - 4/9 - 4 out of 1000 successfully perturbed
fab - 5/9 - 3 out of 1000 successfully perturbed
fab - 6/9 - 2 out of 1000 successfully perturbed
fab - 7/9 - 0 out of 1000 successfully perturbed
fab - 8/9 - 0 out of 1000 successfully perturbed
fab - 9/9 - 1 out of 881 successfully perturbed
robust accuracy after FAB: 88.65% (total time 480.6 s)
square - 1/9 - 35 out of 1000 successfully perturbed
square - 2/9 - 34 out of 1000 successfully perturbed
square - 3/9 - 29 out of 1000 successfully perturbed
square - 4/9 - 29 out of 1000 successfully perturbed
square - 5/9 - 22 out of 1000 successfully perturbed
square - 6/9 - 13 out of 1000 successfully perturbed
square - 7/9 - 19 out of 1000 successfully perturbed
square - 8/9 - 12 out of 1000 successfully perturbed
square - 9/9 - 21 out of 865 successfully perturbed
robust accuracy after SQUARE: 86.51% (total time 749.6 s)
max Linf perturbation: 0.30000, nan in tensor: 0, max: 1.00000, min: 0.00000
robust accuracy: 86.51%

```

As you see, that execution time has significant improvement.