### PR TITLE
Correct BibTeX typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ To log the intermediate results of the evaluation specify `log_path=/path/to/log
 ```
 @inproceedings{croce2020reliable,
     title = {Reliable evaluation of adversarial robustness with an ensemble of diverse parameter-free attacks},
-    authors = {Francesco Croce and Matthias Hein},
+    author = {Francesco Croce and Matthias Hein},
     booktitle = {ICML},
     year = {2020}
 }


### PR DESCRIPTION
Thank you for the interesting work! I tried to cite your paper but noticed your BibTeX is slightly wrong—it should say `author` instead of `authors`. This PR corrects that in case anybody else has the same issue.