### PR TITLE
Try using explicit utf-8 encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
Hi, I was using your repo to build a docker image with your instructions, which is the pip command in README, then I run into an building error that reports that it has some issue with the 5th line in setup.py.

I found simply adding an explicit  encoding="utf-8" parameter can fix the issue. Although I am not very clear about the true causes and I did find that there would be no such problem when directly using pip rather than building a docker, I still believe adding the explicit encoding would be the safer way for others to use your repository. So I initiate this pull request for your consideration. 