### PR TITLE
replace '.view()' with '.reshape()'

### DIFF
--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -184,11 +184,11 @@ class AutoAttack():
             # final check
             if self.verbose:
                 if self.norm == 'Linf':
-                    res = (x_adv - x_orig).abs().view(x_orig.shape[0], -1).max(1)[0]
+                    res = (x_adv - x_orig).abs().reshape(x_orig.shape[0], -1).max(1)[0]
                 elif self.norm == 'L2':
-                    res = ((x_adv - x_orig) ** 2).view(x_orig.shape[0], -1).sum(-1).sqrt()
+                    res = ((x_adv - x_orig) ** 2).reshape(x_orig.shape[0], -1).sum(-1).sqrt()
                 elif self.norm == 'L1':
-                    res = (x_adv - x_orig).abs().view(x_orig.shape[0], -1).sum(dim=-1)
+                    res = (x_adv - x_orig).abs().reshape(x_orig.shape[0], -1).sum(dim=-1)
                 self.logger.log('max {} perturbation: {:.5f}, nan in tensor: {}, max: {:.5f}, min: {:.5f}'.format(
                     self.norm, res.max(), (x_adv != x_adv).sum(), x_adv.max(), x_adv.min()))
                 self.logger.log('robust accuracy: {:.2%}'.format(robust_accuracy))


### PR DESCRIPTION
I had problems with my example:
```
image = tf.io.read_file('./cock.jpg')
image = tf.image.decode_image(image)
image = tf.image.convert_image_dtype(image, tf.float32)
image = tf.image.resize_with_pad(image, target_height=224, target_width=224)
images = tf.keras.applications.resnet50.preprocess_input( image[None,:] * 255)
labels = tf.constant([7])  # imagenet label  "cock"

model = tf.keras.applications.resnet50.ResNet50(include_top=True, weights="imagenet", input_tensor=None,
                                        input_shape=(224, 224, 3), pooling=None, classes=1000)
torch_images = torch.from_numpy( np.transpose(images_1.numpy(), (0, 3, 1, 2)) ).float().cuda()
torch_labels = torch.from_numpy( labels.numpy() ).float()

model_adapted = utils_tf2.ModelAdapter(model)

adversary = AutoAttack(model_adapted, norm='Linf', eps=(8. / 255.), version='standard', is_tf_model=True)
x_adv = adversary.run_standard_evaluation(torch_images, torch_labels, bs=1)
```
error:
```
RuntimeError                              Traceback (most recent call last)
<ipython-input-12-d3e8159c6748> in <module>
      2 
      3 adversary = AutoAttack(model_adapted, norm='Linf', eps=epsilon, version='standard', is_tf_model=True)
----> 4 x_adv = adversary.run_standard_evaluation(torch_images, torch_labels, bs=1)
      5 np_x_adv = np.moveaxis(x_adv.cpu().numpy(), 1, 3)
/dump/mcherepnina/auto-attack/autoattack/autoattack.py in run_standard_evaluation(self, x_orig, y_orig, bs)
--> 187                     res = (x_adv - x_orig).abs().view(x_orig.shape[0], -1).max(1)[0]
    188                 elif self.norm == 'L2':
    189                     res = ((x_adv - x_orig) ** 2).view(x_orig.shape[0], -1).sum(-1).sqrt()
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```
I read about such problem [here](https://stackoverflow.com/questions/49643225/whats-the-difference-between-reshape-and-view-in-pytorch) and replaced '.view()' with '.reshape()'. After that my example starts to work