### PR TITLE
throw VE when attacks to run is specified but version is not 'custom'

### DIFF
--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -24,7 +24,7 @@ class AutoAttack():
         self.device = device
         self.logger = Logger(log_path)
 
-        if version != "custom" and attacks_to_run != []:
+        if version in ['standard', 'plus', 'rand'] and attacks_to_run != []:
             raise ValueError("attacks_to_run will be overridden unless you use version='custom'")
         
         if not self.is_tf_model:

--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -23,6 +23,9 @@ class AutoAttack():
         self.is_tf_model = is_tf_model
         self.device = device
         self.logger = Logger(log_path)
+
+        if version != "custom" and attacks_to_run != []:
+            raise ValueError("attacks_to_run will be overridden unless you use version='custom'")
         
         if not self.is_tf_model:
             from .autopgd_base import APGDAttack


### PR DESCRIPTION
it was quite confusing to me that when i specified attacks to run, it would just overwrite that unless i also specified another argument.