### PR TITLE
Bug Fix | FAB attack targetted version inable to reach

### DIFF
--- a/autoattack/fab_base.py
+++ b/autoattack/fab_base.py
@@ -58,7 +58,7 @@ class FABAttack():
         self.alpha_max = alpha_max
         self.eta = eta
         self.beta = beta
-        self.targeted = False
+        self.targeted = targeted
         self.verbose = verbose
         self.seed = seed
         self.target_class = None


### PR DESCRIPTION
Original autoattack code cannot use FAB-targetted version because of the following code bug.