### PR TITLE
Minor improvement for APGD

### DIFF
--- a/autoattack/autopgd_base.py
+++ b/autoattack/autopgd_base.py
@@ -176,18 +176,17 @@ class APGDAttack():
     def normalize(self, x):
         if self.norm == 'Linf':
             t = x.abs().view(x.shape[0], -1).max(1)[0]
-            return x / (t.view(-1, *([1] * self.ndims)) + 1e-12)
 
         elif self.norm == 'L2':
             t = (x ** 2).view(x.shape[0], -1).sum(-1).sqrt()
-            return x / (t.view(-1, *([1] * self.ndims)) + 1e-12)
 
         elif self.norm == 'L1':
             try:
                 t = x.abs().view(x.shape[0], -1).sum(dim=-1)
             except:
                 t = x.abs().reshape([x.shape[0], -1]).sum(dim=-1)
-            return x / (t.view(-1, *([1] * self.ndims)) + 1e-12)
+
+        return x / (t.view(-1, *([1] * self.ndims)) + 1e-12)
 
     def dlr_loss(self, x, y):
         x_sorted, ind_sorted = x.sort(dim=1)

--- a/autoattack/autopgd_base.py
+++ b/autoattack/autopgd_base.py
@@ -145,10 +145,16 @@ class APGDAttack():
         self.is_tf_model = is_tf_model
         self.y_target = None
         self.logger = logger
-    
-    def init_hyperparam(self, x):
+
         assert self.norm in ['Linf', 'L2', 'L1']
         assert not self.eps is None
+
+        ### set parameters for checkpoints
+        self.n_iter_2 = max(int(0.22 * self.n_iter), 1)
+        self.n_iter_min = max(int(0.06 * self.n_iter), 1)
+        self.size_decr = max(int(0.03 * self.n_iter), 1)
+
+    def init_hyperparam(self, x):
 
         if self.device is None:
             self.device = x.device
@@ -156,16 +162,7 @@ class APGDAttack():
         self.ndims = len(self.orig_dim)
         if self.seed is None:
             self.seed = time.time()
-        
-        
-        
-        
-        
-        ### set parameters for checkpoints
-        self.n_iter_2 = max(int(0.22 * self.n_iter), 1)
-        self.n_iter_min = max(int(0.06 * self.n_iter), 1)
-        self.size_decr = max(int(0.03 * self.n_iter), 1)
-    
+
     def check_oscillation(self, x, j, k, y5, k3=0.75):
         t = torch.zeros(x.shape[1]).to(self.device)
         for counter5 in range(k):

--- a/autoattack/autopgd_base.py
+++ b/autoattack/autopgd_base.py
@@ -191,11 +191,6 @@ class APGDAttack():
             except:
                 t = x.abs().reshape([x.shape[0], -1]).sum(dim=-1)
             return x / (t.view(-1, *([1] * self.ndims)) + 1e-12)
-    
-    def lp_norm(self, x):
-        if self.norm == 'L2':
-            t = (x ** 2).view(x.shape[0], -1).sum(-1).sqrt()
-            return t.view(-1, *([1] * self.ndims))
 
     def dlr_loss(self, x, y):
         x_sorted, ind_sorted = x.sort(dim=1)
@@ -347,11 +342,11 @@ class APGDAttack():
                     x_adv_1 = x_adv + step_size * self.normalize(grad)
                     x_adv_1 = torch.clamp(x + self.normalize(x_adv_1 - x
                         ) * torch.min(self.eps * torch.ones_like(x).detach(),
-                        self.lp_norm(x_adv_1 - x)), 0.0, 1.0)
+                        L2_norm(x_adv_1 - x, keepdim=True)), 0.0, 1.0)
                     x_adv_1 = x_adv + (x_adv_1 - x_adv) * a + grad2 * (1 - a)
                     x_adv_1 = torch.clamp(x + self.normalize(x_adv_1 - x
                         ) * torch.min(self.eps * torch.ones_like(x).detach(),
-                        self.lp_norm(x_adv_1 - x)), 0.0, 1.0)
+                        L2_norm(x_adv_1 - x, keepdim=True)), 0.0, 1.0)
 
                 elif self.norm == 'L1':
                     grad_topk = grad.abs().view(x.shape[0], -1).sort(-1)[0]
@@ -359,8 +354,7 @@ class APGDAttack():
                     grad_topk = grad_topk[u, topk_curr].view(-1, *[1]*(len(x.shape) - 1))
                     sparsegrad = grad * (grad.abs() >= grad_topk).float()
                     x_adv_1 = x_adv + step_size * sparsegrad.sign() / (
-                        sparsegrad.sign().abs().view(x.shape[0], -1).sum(dim=-1).view(
-                        -1, *[1]*(len(x.shape) - 1)) + 1e-10)
+                        L1_norm(sparsegrad.sign(), keepdim=True) + 1e-10)
                     
                     delta_u = x_adv_1 - x
                     delta_p = L1_projection(x, delta_u, self.eps)


### PR DESCRIPTION
This PR is a minor improvement.

1. Remove function `lp_norm`, which has been defined in file `other_utils`
2. Initialize vars and run assertion in constructor
3. Refine function `normalize`, but I prefer the following implementation
```python
de = t.view(-1, *([1] * self.ndims))
ans = torch.where(de < 1e-12, x / (de + 1e-12), x / de)
```

Also, I noticed that function `check_shape` has been defined in APGD and FAB, but `check_shape` dose not be called in APGD. Similarly, some util functions are re-defined in Square attack. I would suggest that those functions should be moved to `other_utils`. Second, var `adv_all` at end of Square attack is not defined.