### PR TITLE
Create attack state

### DIFF
--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -94,12 +94,12 @@ class AutoAttack():
             if self.verbose and state_path is not None:
                 print("Created state in {}".format(state_path))
 
-        attacks_to_run = list(filter(lambda attack: attack not in state.ran_attacks, self.attacks_to_run))
+        attacks_to_run = list(filter(lambda attack: attack not in state.run_attacks, self.attacks_to_run))
         if self.verbose:
             print('using {} version including {}.'.format(self.version,
                   ', '.join(attacks_to_run)))
-            if state.ran_attacks:
-                print('{} was/were already run.'.format(', '.join(state.ran_attacks)))
+            if state.run_attacks:
+                print('{} was/were already run.'.format(', '.join(state.run_attacks)))
 
         # checks on type of defense
         if self.version != 'rand':
@@ -228,13 +228,14 @@ class AutoAttack():
                 
                 robust_accuracy = torch.sum(robust_flags).item() / x_orig.shape[0]
                 robust_accuracy_dict[attack] = robust_accuracy
-                state.add_ran_attack(attack)
+                state.add_run_attack(attack)
                 if self.verbose:
                     self.logger.log('robust accuracy after {}: {:.2%} (total time {:.1f} s)'.format(
                         attack.upper(), robust_accuracy, time.time() - startt))
                     
             # check about square
             checks.check_square_sr(robust_accuracy_dict, logger=self.logger)
+            state.to_disk(force=True)
             
             # final check
             if self.verbose:

--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -87,19 +87,22 @@ class AutoAttack():
         if state_path is not None and state_path.exists():
             state = EvaluationState.from_disk(state_path)
             if self.verbose:
-                print("Restored state from {}".format(state_path))
+                self.logger.log("Restored state from {}".format(state_path))
+                self.logger.log("Since the state has been restored, **only** "
+                                "the adversarial examples from the current run "
+                                "are going to be returned.")
         else:
             state = EvaluationState(path=state_path)
             state.to_disk()
             if self.verbose and state_path is not None:
-                print("Created state in {}".format(state_path))
+                self.logger.log("Created state in {}".format(state_path))                                
 
         attacks_to_run = list(filter(lambda attack: attack not in state.run_attacks, self.attacks_to_run))
         if self.verbose:
-            print('using {} version including {}.'.format(self.version,
+            self.logger.log('using {} version including {}.'.format(self.version,
                   ', '.join(attacks_to_run)))
             if state.run_attacks:
-                print('{} was/were already run.'.format(', '.join(state.run_attacks)))
+                self.logger.log('{} was/were already run.'.format(', '.join(state.run_attacks)))
 
         # checks on type of defense
         if self.version != 'rand':

--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -86,13 +86,16 @@ class AutoAttack():
                                 state_path=None):
         if state_path is not None and state_path.exists():
             state = EvaluationState.from_disk(state_path)
+            if set(self.attacks_to_run) != state.attacks_to_run:
+                raise ValueError("The state was created with a different set of attacks "
+                                 "to run. You are probably using the wrong state file.")
             if self.verbose:
                 self.logger.log("Restored state from {}".format(state_path))
                 self.logger.log("Since the state has been restored, **only** "
                                 "the adversarial examples from the current run "
                                 "are going to be returned.")
         else:
-            state = EvaluationState(path=state_path)
+            state = EvaluationState(set(self.attacks_to_run), path=state_path)
             state.to_disk()
             if self.verbose and state_path is not None:
                 self.logger.log("Created state in {}".format(state_path))                                

--- a/autoattack/examples/eval.py
+++ b/autoattack/examples/eval.py
@@ -68,11 +68,6 @@ if __name__ == '__main__':
         if not args.individual:
             adv_complete = adversary.run_standard_evaluation(x_test[:args.n_ex], y_test[:args.n_ex],
                 bs=args.batch_size, state_path=args.state_path)
-            
-            if args.state_path is not None:
-                warnings.warn(Warning("Since a state path is provided, "
-                                      "the saved adversarial examples are "
-                                      "those obtained in the latest run of the attack."))
 
             torch.save({'adv_complete': adv_complete}, '{}/{}_{}_1_{}_eps_{:.5f}.pth'.format(
                 args.save_dir, 'aa', args.version, adv_complete.shape[0], args.epsilon))
@@ -81,11 +76,6 @@ if __name__ == '__main__':
             # individual version, each attack is run on all test points
             adv_complete = adversary.run_standard_evaluation_individual(x_test[:args.n_ex],
                 y_test[:args.n_ex], bs=args.batch_size)
-            
-            if args.state_path is not None:
-                warnings.warn(Warning("Since a state path is provided, "
-                                      "the saved adversarial examples are "
-                                      "those obtained in the latest run of the attack."))
             
             torch.save(adv_complete, '{}/{}_{}_individual_1_{}_eps_{:.5f}_plus_{}_cheap_{}.pth'.format(
                 args.save_dir, 'aa', args.version, args.n_ex, args.epsilon))

--- a/autoattack/examples/eval.py
+++ b/autoattack/examples/eval.py
@@ -1,6 +1,7 @@
 import os
 import argparse
 from pathlib import Path
+import warnings
 
 import torch
 import torch.nn as nn
@@ -68,6 +69,11 @@ if __name__ == '__main__':
             adv_complete = adversary.run_standard_evaluation(x_test[:args.n_ex], y_test[:args.n_ex],
                 bs=args.batch_size, state_path=args.state_path)
             
+            if args.state_path is not None:
+                warnings.warn(Warning("Since a state path is provided, "
+                                      "the saved adversarial examples are "
+                                      "those obtained in the latest run of the attack."))
+
             torch.save({'adv_complete': adv_complete}, '{}/{}_{}_1_{}_eps_{:.5f}.pth'.format(
                 args.save_dir, 'aa', args.version, adv_complete.shape[0], args.epsilon))
 
@@ -75,6 +81,11 @@ if __name__ == '__main__':
             # individual version, each attack is run on all test points
             adv_complete = adversary.run_standard_evaluation_individual(x_test[:args.n_ex],
                 y_test[:args.n_ex], bs=args.batch_size)
+            
+            if args.state_path is not None:
+                warnings.warn(Warning("Since a state path is provided, "
+                                      "the saved adversarial examples are "
+                                      "those obtained in the latest run of the attack."))
             
             torch.save(adv_complete, '{}/{}_{}_individual_1_{}_eps_{:.5f}_plus_{}_cheap_{}.pth'.format(
                 args.save_dir, 'aa', args.version, args.n_ex, args.epsilon))

--- a/autoattack/examples/eval.py
+++ b/autoattack/examples/eval.py
@@ -1,5 +1,7 @@
 import os
 import argparse
+from pathlib import Path
+
 import torch
 import torch.nn as nn
 import torchvision.datasets as datasets
@@ -23,6 +25,7 @@ if __name__ == '__main__':
     parser.add_argument('--batch_size', type=int, default=500)
     parser.add_argument('--log_path', type=str, default='./log_file.txt')
     parser.add_argument('--version', type=str, default='standard')
+    parser.add_argument('--state-path', type=Path, default=None)
     
     args = parser.parse_args()
 
@@ -63,7 +66,7 @@ if __name__ == '__main__':
     with torch.no_grad():
         if not args.individual:
             adv_complete = adversary.run_standard_evaluation(x_test[:args.n_ex], y_test[:args.n_ex],
-                bs=args.batch_size)
+                bs=args.batch_size, state_path=args.state_path)
             
             torch.save({'adv_complete': adv_complete}, '{}/{}_{}_1_{}_eps_{:.5f}.pth'.format(
                 args.save_dir, 'aa', args.version, adv_complete.shape[0], args.epsilon))

--- a/autoattack/state.py
+++ b/autoattack/state.py
@@ -1,0 +1,49 @@
+import json
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Set
+
+import torch
+
+
+@dataclass
+class EvaluationState:
+    path: Optional[Path] = None
+    _ran_attacks: Set[str] = field(default_factory=set)
+    _robust_flags: Optional[torch.Tensor] = None
+    _last_saved: datetime = datetime(1, 1, 1)
+    _SAVE_TIMEOUT: int = 60
+
+    def to_disk(self) -> None:
+        seconds_since_last_save = (datetime.now() - self._last_saved).total_seconds()
+        if self.path is None or seconds_since_last_save > self._SAVE_TIMEOUT:
+            return
+        d = asdict(self)
+        d["_robust_flags"] = d["_robust_flags"].cpu().tolist()
+        with self.path.open("w") as f:
+            json.dump(asdict(self), f)
+
+    @classmethod
+    def from_disk(cls, path: Path) -> "EvaluationState":
+        with path.open("r") as f:
+            d = json.load(f)
+        d["_robust_flags"] = torch.Tensor(d["_robust_flags"])
+        return cls(path=path, **d)
+
+    @property
+    def robust_flags(self) -> Optional[torch.Tensor]:
+        return self._robust_flags
+
+    @robust_flags.setter
+    def robust_flags(self, robust_flags: torch.Tensor) -> None:
+        self._robust_flags = robust_flags
+        self.to_disk()
+
+    @property
+    def ran_attacks(self) -> Set[str]:
+        return self._ran_attacks
+
+    def add_ran_attack(self, attack: str) -> None:
+        self._ran_attacks.add(attack)
+        self.to_disk()

--- a/autoattack/state.py
+++ b/autoattack/state.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Set
+import warnings
 
 import torch
 
@@ -14,22 +15,33 @@ class EvaluationState:
     _robust_flags: Optional[torch.Tensor] = None
     _last_saved: datetime = datetime(1, 1, 1)
     _SAVE_TIMEOUT: int = 60
+    _clean_accuracy: float = float("nan")
 
-    def to_disk(self) -> None:
-        seconds_since_last_save = (datetime.now() - self._last_saved).total_seconds()
-        if self.path is None or seconds_since_last_save > self._SAVE_TIMEOUT:
+    def to_disk(self, force: bool = False) -> None:
+        seconds_since_last_save = (datetime.now() -
+                                   self._last_saved).total_seconds()
+        if self.path is None or (seconds_since_last_save < self._SAVE_TIMEOUT
+                                 and not force):
             return
         d = asdict(self)
-        d["_robust_flags"] = d["_robust_flags"].cpu().tolist()
-        with self.path.open("w") as f:
-            json.dump(asdict(self), f)
+        if self.robust_flags is not None:
+            d["_robust_flags"] = d["_robust_flags"].cpu().tolist()
+        d["_ran_attacks"] = list(self._ran_attacks)
+        with self.path.open("w", ) as f:
+            json.dump(d, f, default=str)
 
     @classmethod
     def from_disk(cls, path: Path) -> "EvaluationState":
         with path.open("r") as f:
             d = json.load(f)
-        d["_robust_flags"] = torch.Tensor(d["_robust_flags"])
-        return cls(path=path, **d)
+        d["_robust_flags"] = torch.tensor(d["_robust_flags"], dtype=torch.bool)
+        if path != Path(d["path"]):
+            warnings.warn(
+                UserWarning(
+                    "The given path is different from the one found in the state file."
+                ))
+        d["_last_saved"] = datetime.fromisoformat(d["_last_saved"])
+        return cls(**d)
 
     @property
     def robust_flags(self) -> Optional[torch.Tensor]:
@@ -38,7 +50,7 @@ class EvaluationState:
     @robust_flags.setter
     def robust_flags(self, robust_flags: torch.Tensor) -> None:
         self._robust_flags = robust_flags
-        self.to_disk()
+        self.to_disk(force=True)
 
     @property
     def ran_attacks(self) -> Set[str]:
@@ -47,3 +59,12 @@ class EvaluationState:
     def add_ran_attack(self, attack: str) -> None:
         self._ran_attacks.add(attack)
         self.to_disk()
+
+    @property
+    def clean_accuracy(self) -> float:
+        return self._clean_accuracy
+
+    @clean_accuracy.setter
+    def clean_accuracy(self, accuracy) -> None:
+        self._clean_accuracy = accuracy
+        self.to_disk(force=True)


### PR DESCRIPTION
This PR introduces a state for the attack so that the results can be restored in case the evaluation gets interrupted, and the state can be resumed (e.g., because the resources used for the evaluation are preempted).

The state is a `dataclass` which saves the following information:

- the path where the state is saved on disk
- the attacks that have been run so far
- a `bool` for each image to attack, where `False` means that the image has already been successfully attacked
- the time when the state was last saved to disk. This is to avoid bloating I/O by saving the state too often. By using this, the state is saved at most once every 60s.
- the clean accuracy computed at the beginning of the evaluation

It's not necessary to save the robust accuracy, as it can be easily computed by doing `torch.sum(robust_flags).item() / robust_flags.shape[0]`.

To save and restore the state, it's enough to pass the path where the state has to be (or is already) saved to `AutoAttack.run_standard_evaluation`.