### PR TITLE
Fixed random escape from attack problem of random evaluation

### DIFF
--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -135,7 +135,7 @@ class AutoAttack():
                         output = self.get_logits(x).max(dim=1)[1]
                         y_adv[start_idx: end_idx] = output
                         correct_batch = y.eq(output)
-                        robust_flags[start_idx:end_idx] = correct_batch.detach().to(robust_flags.device)
+                        robust_flags[start_idx:end_idx] += correct_batch.detach().to(robust_flags.device)
                         
                 robust_flags /= self.apgd.eot_iter
                 state.robust_flags = robust_flags

--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -336,6 +336,7 @@ class AutoAttack():
             self.fab.n_target_classes = 9
             #self.apgd_targeted.n_target_classes = 9
             self.square.n_queries = 5000
+            self.apgd.eot_iter = 20
         
         elif version == 'plus':
             self.attacks_to_run = ['apgd-ce', 'apgd-dlr', 'fab', 'square', 'apgd-t', 'fab-t']
@@ -345,6 +346,7 @@ class AutoAttack():
             self.fab.n_target_classes = 9
             self.apgd_targeted.n_target_classes = 9
             self.square.n_queries = 5000
+            self.apgd.eot_iter = 1
             if not self.norm in ['Linf', 'L2']:
                 print('"{}" version is used with {} norm: please check'.format(
                     version, self.norm))

--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -137,12 +137,13 @@ class AutoAttack():
                 robust_flags = torch.zeros(x_orig.shape[0], device=x_orig.device)
                 y_adv = torch.empty_like(y_orig)
                 for batch_idx in range(n_batches):
-                    for _ in range(self.eval_iter):
-                        start_idx = batch_idx * bs
-                        end_idx = min( (batch_idx + 1) * bs, x_orig.shape[0])
+                    start_idx = batch_idx * bs
+                    end_idx = min((batch_idx + 1) * bs, x_orig.shape[0])
 
-                        x = x_orig[start_idx:end_idx, :].clone().to(self.device)
-                        y = y_orig[start_idx:end_idx].clone().to(self.device)
+                    x = x_orig[start_idx:end_idx, :].clone().to(self.device)
+                    y = y_orig[start_idx:end_idx].clone().to(self.device)
+
+                    for _ in range(self.eval_iter):
                         output = self.get_logits(x).max(dim=1)[1]
                         y_adv[start_idx: end_idx] = output
                         correct_batch = y.eq(output)

--- a/autoattack/autoattack.py
+++ b/autoattack/autoattack.py
@@ -126,7 +126,7 @@ class AutoAttack():
                 robust_flags = torch.zeros(x_orig.shape[0], device=x_orig.device)
                 y_adv = torch.empty_like(y_orig)
                 for batch_idx in range(n_batches):
-                    for eot_iter in range(self.apgd.eot_iter):
+                    for _ in range(self.apgd.eot_iter):
                         start_idx = batch_idx * bs
                         end_idx = min( (batch_idx + 1) * bs, x_orig.shape[0])
 
@@ -232,7 +232,7 @@ class AutoAttack():
                     # y_adv[non_robust_lin_idcs] = output[false_batch].detach().to(x_adv.device)
                     
                     correct_batch = torch.zeros_like(y)
-                    for eot_iter in range(self.apgd.eot_iter):
+                    for _ in range(self.apgd.eot_iter):
                         output = self.get_logits(adv_curr).max(dim=1)[1]
                         correct_batch += y.eq(output).to(robust_flags.device)
                     

--- a/autoattack/checks.py
+++ b/autoattack/checks.py
@@ -15,7 +15,7 @@ funcs = {'grad': 0,
 checks_doc_path = 'flags_doc.md'
 
 
-def check_randomized(model, x, y, bs=250, n=5, alpha=1e-4, logger=None):
+def is_randomized(model, x, y, bs=250, n=5, alpha=1e-4, logger=None):
     acc = []
     corrcl = []
     outputs = []
@@ -39,6 +39,8 @@ def check_randomized(model, x, y, bs=250, n=5, alpha=1e-4, logger=None):
             warnings.warn(Warning(msg))
         else:
             logger.log(f'Warning: {msg}')
+        return True
+    return False
 
 
 def check_range_output(model, x, alpha=1e-5, logger=None):


### PR DESCRIPTION
**@Buntender and me put forward this PR to improve Random attack evaluation.**

We can obviously observe that when autoattack evaluates a model with relatively strong randomness (such as DiffPure), in the attack stage due to weak defense capability and random output error results,  Attacker will be deceived and give up trying a stronger attack after a successful attack. This phenomenon can lead to higher false robustness measurements, and even worse results from stronger attacks on otherwise more robust models. Through multiple EOT evaluations and the "relatively lower accuracy" adversarial sample screening method, our PR avoids the problem of screening adversarial samples only once, making the evaluation of random defense more stable and accurate.