### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 data/
-/__pycache__/
-*/__pycache__/
 
+# python
 build/
 dist/
 *.egg-info/
+*.egg
+*.py[cod]
+__pycache__/
+*.so
+*~


### PR DESCRIPTION
Hi,

If the original `.gitignore` is used, `__pycache__`  in some places will not be ignored.

So I update `.gitignore` to ignore build files and `__pycache__` everywhere.

